### PR TITLE
fixes #46

### DIFF
--- a/imports/ui/components/apply.jsx
+++ b/imports/ui/components/apply.jsx
@@ -80,7 +80,7 @@ class Apply extends React.Component {
 
             <Form.Group controlId="oneLineIntro">
               <Form.Label>One-line intro of yourself:</Form.Label>
-              <Form.Control type="text" required defaultValue={oneLineIntro} pattern="[A-Za-z0-9\s\.]{8,140}" />
+              <Form.Control type="text" required defaultValue={oneLineIntro} pattern="[A-Za-z0-9,!?\x27\x22\s\.]{8,140}" />
               <Form.Control.Feedback type="invalid">Please share an intro between 8 and 140 characters long.</Form.Control.Feedback>
             </Form.Group>
 


### PR DESCRIPTION
See #46.

Now, one line intro supports following characters `,` `?` `!` `'` `"`.
