### PR TITLE
Increment node version to >= 10.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "commit": "git-cz"
   },
   "engines": {
-    "node": "8.11.4"
+    "node": ">=10.0.0"
   },
   "dependencies": {
     "@babel/runtime": "7.2.0",


### PR DESCRIPTION
Addresses issue #58 by defining a minimum of version of node to the latest major version, instead of locking to a specific version (previously locked to `8.11.4`)