### PR TITLE
Update Travis build actions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ before_script:
   - export PATH=$HOME/.meteor:$PATH
   # Install all the dependencies! 
   - npm install
+script:
+  - npm run lint
 services:
   - mongodb
 cache:

--- a/package.json
+++ b/package.json
@@ -3,13 +3,12 @@
   "private": true,
   "scripts": {
     "start": "meteor run",
-    "pretest": "npm run prettier && npm run lint",
     "test:meteor": "meteor test --once --driver-package meteortesting:mocha",
     "test:meteor-app": "TEST_WATCH=1 meteor test --full-app --driver-package meteortesting:mocha",
     "test": "jest",
     "lint": "eslint . --ext .js --ext .jsx",
     "lint:fix": "eslint . --ext .js --ext .jsx --fix",
-    "prettier": "prettier --write \"./**/*.{js,jsx}\"",
+    "prettier:all": "prettier --write \"./**/*.{js,jsx}\"",
     "prettier:check": "prettier -l \"./**/*.{js,jsx}\"",
     "visualize": "meteor --production --extra-packages bundle-visualizer",
     "commit": "git-cz"


### PR DESCRIPTION
Remove running prettier as a `pretest` script as prettier runs as a pre-commit
hook through Husky and Lint-Staged already. Set Travis script to only run ESLint
with running tests.