### PR TITLE
redirect user to dashboard after resetting password

### DIFF
--- a/client/pages/set_password.jsx
+++ b/client/pages/set_password.jsx
@@ -53,7 +53,7 @@ class SetPassword extends Component {
         } else {
           this.setState({ processing: false });
           this.setState({ success: 'Welcome To CB Connect !' });
-          this.props.history.push('/');
+          this.props.history.push('/dashboard');
         }
       });
     }


### PR DESCRIPTION
## Description
This will resolve issue #50. Just added a minor change to push the browser history to `/dashboard` url after resetting the user's password.